### PR TITLE
Removed bl.spamcannibal.org and updated Go to 1.12.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.4
+FROM golang:1.12.5
 
 ENV GOPACKAGE github.com/Barzahlen/nagios-dnsblklist
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,6 @@ var BlacklistServers = []string{
 	"all.s5h.net",
 	"b.barracudacentral.org",
 	"bl.emailbasura.org",
-	"bl.spamcannibal.org",
 	"bl.spamcop.net",
 	"blacklist.woody.ch",
 	"bogons.cymru.com",


### PR DESCRIPTION
Removes the defective spam blacklist and updates Go to 1.12.5