### PR TITLE
Merge sbl./pbl./xbl.spamhaus.org into zen.spamhaus.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.7] - 2022-07-25
+- Remove sbl./pbl./xbl.spamhaus.org DNSBLs in favor of [zen.spamhaus.org](https://www.spamhaus.org/zen/) which combines answers for all of them
+
 ## [2.0.6] - 2022-07-14
 - Removed [cbl.abuseat.org](https://www.abuseat.org/)
 - Updated Go version to 1.18.4

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,12 +58,10 @@ var BlacklistServers = []string{
 	"misc.dnsbl.sorbs.net",
 	"noptr.spamrats.com",
 	"orvedb.aupads.org",
-	"pbl.spamhaus.org",
 	"proxy.bl.gweep.ca",
 	"psbl.surriel.com",
 	"relays.bl.gweep.ca",
 	"relays.nether.net",
-	"sbl.spamhaus.org",
 	"short.rbl.jp",
 	"singular.ttk.pte.hu",
 	"smtp.dnsbl.sorbs.net",
@@ -80,7 +78,6 @@ var BlacklistServers = []string{
 	"virus.rbl.jp",
 	"web.dnsbl.sorbs.net",
 	"wormrbl.imp.ch",
-	"xbl.spamhaus.org",
 	"z.mailspike.net",
 	"zen.spamhaus.org",
 	"zombie.dnsbl.sorbs.net",
@@ -100,7 +97,7 @@ ip-address is listed on a blacklist server.
 
 The ip-address is checked against a list of all relevant blacklist servers.
 
-Current Version: 2.0.6`,
+Current Version: 2.0.7`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	//	Run: func(cmd *cobra.Command, args []string) { },


### PR DESCRIPTION
Spamhaus provides the zen.spamhaus.org (https://www.spamhaus.org/zen/) list which combines answer for all of their individual DNSBLs. Therefore we can save us 3 additional requests per run and reduce chance to hit the free rate-limit by only parsing zen.spamhaus.org.